### PR TITLE
Up CB for new feelpp.benchmarking release

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -128,7 +128,8 @@ jobs:
                     -mc machine_config.json \
                     -bc ${{ github.event.inputs.benchmark_config || github.event.client_payload.benchmark_config }} \
                     -pc ${{ github.event.inputs.plots_config || github.event.client_payload.plots_config}} \
-                    -v
+                    -v \
+                    -rfm "-v --exec-order=name --max-retries=2"
             env:
                 GIRDER_API_KEY: ${{ secrets.GIRDER }}
                 PROJECT_ID: ${{matrix.project_id || ''}}


### PR DESCRIPTION
feelpp.benchmarking will now allow to pass ReFrame specific options through the `feelpp-benchmarking-exec`. The benchmarking workflow was updated to :
- Order tests by ascending name ( lowest nb_nodes and smaller meshes first )
- Retry tests if failed. (max retries = 2, will not show in report yet, but data will be available.) 