### PR TITLE
45 fix quadrature order variation use case

### DIFF
--- a/config/solarmasks/quadrature.json
+++ b/config/solarmasks/quadrature.json
@@ -98,10 +98,13 @@
                 "variables_path":["*.timeElapsed.max","*.subtimers.*.timeElapsed.max"]
             },
             {
-                "name":"Outputs",
+                "name":"SolarMasks",
                 "filepath": "instances/np_{{variables.tasks}}/report/report.json",
                 "format": "json",
-                "variables_path":["buildings.total.outputs.solarShadingCoefficients.mean"]
+                "variables_path":["buildings.total.outputs.solarShadingCoefficients.mean"],
+                "units":{
+                    "*":""
+                }
             }
         ]
     },

--- a/config/solarmasks/quadrature.json
+++ b/config/solarmasks/quadrature.json
@@ -58,7 +58,7 @@
         "--cem.instance.time.step={{variables.time.step}}",
 
         "--cem.instance.postprocess.export.visualization.enabled=false",
-        "--cem.instance.postprocess.export.report.enabled=false",
+        "--cem.instance.postprocess.export.report.enabled=true",
         "--cem.instance.postprocess.export.outputs.csv.enabled=false",
         "--cem.instance.postprocess.export.outputs.enabled=false",
 

--- a/config/solarmasks/quadrature.json
+++ b/config/solarmasks/quadrature.json
@@ -96,6 +96,12 @@
                 "filepath": "log/timers.json",
                 "format": "json",
                 "variables_path":["*.timeElapsed.max","*.subtimers.*.timeElapsed.max"]
+            },
+            {
+                "name":"Outputs",
+                "filepath": "instances/np_{{variables.tasks}}/report/report.json",
+                "format": "json",
+                "variables_path":["buildings.total.outputs.solarShadingCoefficients.mean"]
             }
         ]
     },

--- a/config/solarmasks/quadrature_plots.json
+++ b/config/solarmasks/quadrature_plots.json
@@ -20,16 +20,6 @@
         "color_axis": { "parameter": "performance_variable", "label": "Step" }
     },
     {
-        "title": "Solar Masks - Speedup",
-        "plot_types": [ "scatter" ],
-        "transformation": "speedup",
-        "variables": [ "simulation.solarMasks"],
-        "names": ["solarMasks"],
-        "xaxis": { "parameter": "quad_ord", "label": "Quadrature Order" },
-        "yaxis": { "label": "speedup"},
-        "color_axis": { "parameter": "performance_variable", "label": "Step" }
-    },
-    {
         "title": "solarMasks Iteration Statistics",
         "plot_types": [ "scatter"],
         "transformation": "performance",
@@ -40,13 +30,35 @@
         "color_axis": { "parameter": "performance_variable", "label": "Statistics" }
     },
     {
-        "title": "solarMasks Iteration Max -- Speedup",
-        "plot_types": [ "scatter"],
-        "transformation": "speedup",
-        "variables": [ "Statistics_simulation.solarMasks.iterMax.max"],
-        "names": ["Max"],
-        "xaxis": { "parameter": "quad_ord", "label": "Quadrature Order" },
-        "yaxis": { "label": "speedup"},
-        "color_axis": { "parameter": "performance_variable", "label": "Average" }
+        "title":"Solar mask convergence",
+        "plot_types":["scatter"],
+        "transformation":"performance",
+        "variables":[
+            "Outputs_mean.8",
+            "Outputs_mean.9",
+            "Outputs_mean.10",
+            "Outputs_mean.11",
+            "Outputs_mean.12",
+            "Outputs_mean.13",
+            "Outputs_mean.14",
+            "Outputs_mean.15",
+            "Outputs_mean.16",
+            "Outputs_mean.17"
+        ],
+        "names":[
+            "09",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18"
+        ],
+        "xaxis": { "parameter": "performance_variable", "label": "Time" },
+        "yaxis": { "label": "solar shading coefficient"},
+        "color_axis": { "parameter": "quad_ord", "label": "Quadrature Order" }
     }
 ]}

--- a/config/solarmasks/quadrature_plots.json
+++ b/config/solarmasks/quadrature_plots.json
@@ -34,16 +34,16 @@
         "plot_types":["scatter"],
         "transformation":"performance",
         "variables":[
-            "Outputs_mean.8",
-            "Outputs_mean.9",
-            "Outputs_mean.10",
-            "Outputs_mean.11",
-            "Outputs_mean.12",
-            "Outputs_mean.13",
-            "Outputs_mean.14",
-            "Outputs_mean.15",
-            "Outputs_mean.16",
-            "Outputs_mean.17"
+            "SolarMasks_mean.8",
+            "SolarMasks_mean.9",
+            "SolarMasks_mean.10",
+            "SolarMasks_mean.11",
+            "SolarMasks_mean.12",
+            "SolarMasks_mean.13",
+            "SolarMasks_mean.14",
+            "SolarMasks_mean.15",
+            "SolarMasks_mean.16",
+            "SolarMasks_mean.17"
         ],
         "names":[
             "09",


### PR DESCRIPTION
- Closes #45 

Will be able to visualise performance variations depending on the quadrature order. 
Even a solar masks average convergence analysis is possible.  (figure will only be visible after https://github.com/feelpp/benchmarking/pull/315 )


Little previews: 

![newplot-35](https://github.com/user-attachments/assets/4f4dc557-572f-4c3d-b455-ae1f4f9d7d12)
![newplot-36](https://github.com/user-attachments/assets/d9749e44-4363-4063-8446-6f10b9ac6e75)
